### PR TITLE
Support boolean, long, double and timestamp column

### DIFF
--- a/src/main/java/org/embulk/output/google_spreadsheets/GoogleSpreadsheetsOutputPlugin.java
+++ b/src/main/java/org/embulk/output/google_spreadsheets/GoogleSpreadsheetsOutputPlugin.java
@@ -167,26 +167,46 @@ public class GoogleSpreadsheetsOutputPlugin
                 pageReader.getSchema().visitColumns(new ColumnVisitor() {
                     @Override
                     public void booleanColumn(Column column) {
-                        log.debug("booleanColumn: " + pageReader.getString(column));
-                        row.getCustomElements().setValueLocal(column.getName(), pageReader.getString(column));
+                        if (pageReader.isNull(column)) {
+                            log.debug("booleanColumn: null");
+                            row.getCustomElements().setValueLocal(column.getName(), "");
+                        } else {
+                            log.debug("booleanColumn: " + pageReader.getBoolean(column));
+                            row.getCustomElements().setValueLocal(column.getName(), (pageReader.getBoolean(column) ? "true" : "false"));
+                        }
                     }
 
                     @Override
                     public void longColumn(Column column) {
-                        log.debug("longColumn: " + pageReader.getString(column));
-                        row.getCustomElements().setValueLocal(column.getName(), pageReader.getString(column));
+                        if (pageReader.isNull(column)) {
+                            log.debug("longColumn: null");
+                            row.getCustomElements().setValueLocal(column.getName(), "");
+                        } else {
+                            log.debug("longColumn: " + pageReader.getLong(column));
+                            row.getCustomElements().setValueLocal(column.getName(), Long.toString(pageReader.getLong(column)));
+                        }
                     }
 
                     @Override
                     public void doubleColumn(Column column) {
-                        log.debug("doubleColumn: " + pageReader.getString(column));
-                        row.getCustomElements().setValueLocal(column.getName(), pageReader.getString(column));
+                        if (pageReader.isNull(column)) {
+                            log.debug("doubleColumn: null");
+                            row.getCustomElements().setValueLocal(column.getName(), "");
+                        } else {
+                            log.debug("doubleColumn: " + pageReader.getDouble(column));
+                            row.getCustomElements().setValueLocal(column.getName(), Double.toString(pageReader.getDouble(column)));
+                        }
                     }
 
                     @Override
                     public void stringColumn(Column column) {
-                        log.debug("stringColumn: " + pageReader.getString(column));
-                        row.getCustomElements().setValueLocal(column.getName(), pageReader.getString(column));
+                        if (pageReader.isNull(column)) {
+                            log.debug("stringColumn: null");
+                            row.getCustomElements().setValueLocal(column.getName(), "");
+                        } else {
+                            log.debug("stringColumn: " + pageReader.getString(column));
+                            row.getCustomElements().setValueLocal(column.getName(), pageReader.getString(column));
+                        }
                     }
 
                     @Override


### PR DESCRIPTION
The current version of the plugin fails if it receives any columns other than string. 

This merge request is intended to support boolean/long/double/timestamp column and NULL value.  
For timestamp column, I added default_timezone config (default: UTC) in a manner similar to built-in csv parser.

Example:

```
out:
  type: google_spreadsheets
  service_account_email: 'XXXXXXXXXXXXXXXXXXXXXXXX@developer.gserviceaccount.com'
  p12_keyfile: '/tmp/embulk.p12'
  spreadsheet_id: '1RPXaB85DXM7sGlpFYIcpoD2GWFpktgh0jBHlF4m1a0A'
  default_timezone: Asia/Tokyo
```
